### PR TITLE
Replace the discontinued Riksbank SOAP API with the new REST one

### DIFF
--- a/Scripts/EtradeDividends.ps1
+++ b/Scripts/EtradeDividends.ps1
@@ -1,68 +1,57 @@
-# Helper for acquiring the archival exchange rate for a given date.
-function Get-SEKUSDPMIAtDate ([datetime]$Date)
+# Helper for acquiring the archival exchange rates for a given list of dates.
+function Get-SEKUSDPMIAtDateRange ([DateTime[]]$Dates)
 {
-	$groups = $null
+	# Extend "earliest" by a week to make sure we have data even if the earliest date falls on a red day in Sweden.
+	$earliest = $(($Dates | Measure-Object -Minimum).Minimum).AddDays(-7.0)
+	$latest = ($Dates | Measure-Object -Maximum).Maximum
+	return $(Invoke-RestMethod -Uri $([string]::Format("https://api.riksbank.se/swea/v1/Observations/SEKUSDPMI/{0}/{1}", $earliest.ToString("yyyy-MM-dd"), $latest.ToString("yyyy-MM-dd"))) -Method Get)
+}
+
+# Helper for querying the exchange rate array acquired with the above call for a given date.
+function Get-SEKUSDPMIAtDate ($rates, [datetime]$Date)
+{
+	$rate = $null
 	do
 	{
-		$body = [string]::Format('<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://swea.riksbank.se/xsd">
-     <soap:Header/>
-     <soap:Body>
-         <xsd:getInterestAndExchangeRates>
-             <searchRequestParameters>
-                 <aggregateMethod>D</aggregateMethod>
-                 <datefrom>{0}</datefrom>
-                 <dateto>{0}</dateto>
-                 <languageid>en</languageid>
-                 <min>false</min>
-                 <avg>true</avg>
-                 <max>true</max>
-                 <ultimo>false</ultimo>
-                 <!--1 or more repetitions:-->
-                 <searchGroupSeries>
-                     <groupid>11</groupid>
-                     <seriesid>SEKUSDPMI</seriesid>
-                 </searchGroupSeries>
-             </searchRequestParameters>
-         </xsd:getInterestAndExchangeRates>
-     </soap:Body>
- </soap:Envelope>', $Date.ToString("yyyy-MM-dd"))
-		$groups = $([xml]$(Invoke-WebRequest -Method Post -Headers @{'Content-Type'='application/soap+xml;charset=utf-8;action=urn:getInterestAndExchangeRates'} -Body $body -Uri 'https://swea.riksbank.se/sweaWS/services/SweaWebServiceHttpSoap12Endpoint' -UseBasicParsing)."Content").Envelope.body.getInterestAndExchangeRatesResponse.return.groups
-		# Scan backwards in time for the latest rate, if the response for the current is empty.
-		if ($null -eq $groups) { Write-Host $([string]::Format("No exchange rate for {0}, trying the previous day", $Date.ToString("yyyy-MM-dd"))) }
+		$rate = $rates | Where-Object { $_.date -eq $($Date.ToString("yyyy-MM-dd")) }
+		# Scan backwards in time for the latest rate, if there's no record for the current.
+		if ($null -eq $rate) { Write-Host $([string]::Format("No exchange rate for {0}, trying the previous day", $Date.ToString("yyyy-MM-dd"))) }
 		$Date = $Date.AddDays(-1.0)
 	}
-	while ($null -eq $groups)
-	return [double]$groups.series.resultrows.value.'#text'
+	while ($null -eq $rate)
+	#Write-Host $([string]::Format("Exchange rate for {0} is {1}", $Date.ToString("yyyy-MM-dd"), $rate.value))
+	return [double]$rate.value
 }
 
 $cashTransactions = $(get-content -raw -path getCashTransactions.json | ConvertFrom-Json).data.value.cashTransactionActivities
+$dividendTransactions = $cashTransactions | Where-Object { $_.transactionType -eq "$+-DIV" }
 
-$p72 = @()
 $totalDividendUSD = 0.0
 $totalTaxUSD = 0.0
 $totalDividendSEK = 0
 $totalTaxSEK = 0
 
-foreach ($ct in $cashTransactions)
+# The new REST API is rate-limited. We need to fetch data for the interval, and then sample the specific days.
+$divDates = $dividendTransactions | ForEach-Object { [datetime]::ParseExact($_.transactionDate, "MM/dd/yyyy", $null) }
+$rates = Get-SEKUSDPMIAtDateRange $divDates
+
+foreach ($ct in $dividendTransactions)
 {
-	if ($ct.transactionType -eq "$+-DIV")
-	{
-		$txDate = [datetime]::ParseExact($ct.transactionDate, "MM/dd/yyyy", $null)
-		$txRate = Get-SEKUSDPMIAtDate($txDate)
-		
-		$tx = $ct.amount
-		$txSEK = [int][math]::Round($tx * $txRate)
-		
-		$dividendUSD = [math]::Max(0.0, $tx)
-		$taxUSD = [math]::Min(0.0, $tx)
-		$dividendSEK = [math]::Max(0, $txSEK)
-		$taxSEK = [math]::Min(0, $txSEK)
-		
-		$totalDividendUSD += $dividendUSD
-		$totalTaxUSD += $taxUSD
-		$totalDividendSEK += $dividendSEK
-		$totalTaxSEK += $taxSEK
-	}
+	$txDate = [datetime]::ParseExact($ct.transactionDate, "MM/dd/yyyy", $null)
+	$txRate = Get-SEKUSDPMIAtDate $rates $txDate
+	
+	$tx = $ct.amount
+	$txSEK = [int][math]::Round($tx * $txRate)
+	
+	$dividendUSD = [math]::Max(0.0, $tx)
+	$taxUSD = [math]::Min(0.0, $tx)
+	$dividendSEK = [math]::Max(0, $txSEK)
+	$taxSEK = [math]::Min(0, $txSEK)
+	
+	$totalDividendUSD += $dividendUSD
+	$totalTaxUSD += $taxUSD
+	$totalDividendSEK += $dividendSEK
+	$totalTaxSEK += $taxSEK
 }
 
 $totalDividendUSD = [math]::Round($totalDividendUSD)

--- a/Scripts/EtradeK4.ps1
+++ b/Scripts/EtradeK4.ps1
@@ -1,41 +1,30 @@
-# Helper for acquiring the archival exchange rate for a given date.
-function Get-SEKUSDPMIAtDate ([datetime]$Date)
+# Helper for acquiring the archival exchange rates for a given list of dates.
+function Get-SEKUSDPMIAtDateRange ([DateTime[]]$Dates)
 {
-	$groups = $null
+	# Extend "earliest" by a week to make sure we have data even if the earliest date falls on a red day in Sweden.
+	$earliest = $(($Dates | Measure-Object -Minimum).Minimum).AddDays(-7.0)
+	$latest = ($Dates | Measure-Object -Maximum).Maximum
+	return $(Invoke-RestMethod -Uri $([string]::Format("https://api.riksbank.se/swea/v1/Observations/SEKUSDPMI/{0}/{1}", $earliest.ToString("yyyy-MM-dd"), $latest.ToString("yyyy-MM-dd"))) -Method Get)
+}
+
+# Helper for querying the exchange rate array acquired with the above call for a given date.
+function Get-SEKUSDPMIAtDate ($rates, [datetime]$Date)
+{
+	$rate = $null
 	do
 	{
-		$body = [string]::Format('<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://swea.riksbank.se/xsd">
-	 <soap:Header/>
-	 <soap:Body>
-		 <xsd:getInterestAndExchangeRates>
-			 <searchRequestParameters>
-				 <aggregateMethod>D</aggregateMethod>
-				 <datefrom>{0}</datefrom>
-				 <dateto>{0}</dateto>
-				 <languageid>en</languageid>
-				 <min>false</min>
-				 <avg>true</avg>
-				 <max>true</max>
-				 <ultimo>false</ultimo>
-				 <!--1 or more repetitions:-->
-				 <searchGroupSeries>
-					 <groupid>11</groupid>
-					 <seriesid>SEKUSDPMI</seriesid>
-				 </searchGroupSeries>
-			 </searchRequestParameters>
-		 </xsd:getInterestAndExchangeRates>
-	 </soap:Body>
- </soap:Envelope>', $Date.ToString("yyyy-MM-dd"))
-		$groups = $([xml]$(Invoke-WebRequest -Method Post -Headers @{'Content-Type'='application/soap+xml;charset=utf-8;action=urn:getInterestAndExchangeRates'} -Body $body -Uri 'https://swea.riksbank.se/sweaWS/services/SweaWebServiceHttpSoap12Endpoint' -UseBasicParsing)."Content").Envelope.body.getInterestAndExchangeRatesResponse.return.groups
-		# Scan backwards in time for the latest rate, if the response for the current is empty.
-		if ($null -eq $groups) { Write-Host $([string]::Format("No exchange rate for {0}, trying the previous day", $Date.ToString("yyyy-MM-dd"))) }
+		$rate = $rates | Where-Object { $_.date -eq $($Date.ToString("yyyy-MM-dd")) }
+		# Scan backwards in time for the latest rate, if there's no record for the current.
+		if ($null -eq $rate) { Write-Host $([string]::Format("No exchange rate for {0}, trying the previous day", $Date.ToString("yyyy-MM-dd"))) }
 		$Date = $Date.AddDays(-1.0)
 	}
-	while ($null -eq $groups)
-	return [double]$groups.series.resultrows.value.'#text'
+	while ($null -eq $rate)
+	#Write-Host $([string]::Format("Exchange rate for {0} is {1}", $Date.ToString("yyyy-MM-dd"), $rate.value))
+	return [double]$rate.value
 }
 
 $gainsLosses = $(get-content -raw -path gainsLosses.json | ConvertFrom-Json).data.gainsAndLosses.list.gainsLossDtlsList
+$saleTransactions = $gainsLosses | Where-Object { $_.transactionType -eq "Sell" }
 
 $k4 = @()
 $totalClosing = 0
@@ -43,50 +32,54 @@ $totalClosingSEK = 0
 $totalOpening = 0
 $totalOpeningSEK = 0
 
-foreach ($ct in $gainsLosses)
+# The new REST API is rate-limited. We need to fetch data for the interval, and then sample the specific days.
+$rates = Get-SEKUSDPMIAtDateRange $($saleTransactions | ForEach-Object {
+	$closingDate = [datetime]::ParseExact($_.closingTransDateSold, "MM/dd/yyyy", $null)
+	$openingDate = [datetime]::ParseExact($_.openingTransDateAcquired, "MM/dd/yyyy", $null)
+	$openingDate, $closingDate
+})
+
+foreach ($ct in $saleTransactions)
 {
-	if ($ct.transactionType -eq "Sell")
-	{
-		$txDate = [datetime]::ParseExact($ct.closingTransDateSold, "MM/dd/yyyy", $null)
-		$txRate = Get-SEKUSDPMIAtDate($txDate)
-		
-		$tx = $ct.closingTransTotalProceeds
-		$txSEK = [int][math]::Round($tx * $txRate)
-		
-		$closingTransTotalProceeds = [math]::Max(0.0, $tx)
-		$closingTransTotalProceedsSEK = [math]::Max(0, $txSEK)
+	$txDate = [datetime]::ParseExact($ct.closingTransDateSold, "MM/dd/yyyy", $null)
+	$txRate = Get-SEKUSDPMIAtDate $rates $txDate
+	
+	$tx = $ct.closingTransTotalProceeds
+	$txSEK = [int][math]::Round($tx * $txRate)
+	
+	$closingTransTotalProceeds = [math]::Max(0.0, $tx)
+	$closingTransTotalProceedsSEK = [math]::Max(0, $txSEK)
 
-		$txDate = [datetime]::ParseExact($ct.openingTransDateAcquired, "MM/dd/yyyy", $null)
-		$txRate = Get-SEKUSDPMIAtDate($txDate)
+	$txDate = [datetime]::ParseExact($ct.openingTransDateAcquired, "MM/dd/yyyy", $null)
+	$txRate = Get-SEKUSDPMIAtDate $rates $txDate
 
-		$tx = $ct.openingTransAdjCostBasis
-		$txSEK = [int][math]::Round($tx * $txRate)
+	$tx = $ct.openingTransAdjCostBasis
+	$txSEK = [int][math]::Round($tx * $txRate)
 
-		$openingTransAdjCostBasis = [math]::Max(0.0, $tx)
-		$openingTransAdjCostBasisSEK = [math]::Max(0, $txSEK)
-		
-		$totalClosing += $closingTransTotalProceeds
-		$totalClosingSEK += $closingTransTotalProceedsSEK
-		$totalOpening += $openingTransAdjCostBasis
-		$totalOpeningSEK += $openingTransAdjCostBasisSEK
+	$openingTransAdjCostBasis = [math]::Max(0.0, $tx)
+	$openingTransAdjCostBasisSEK = [math]::Max(0, $txSEK)
+	
+	$totalClosing += $closingTransTotalProceeds
+	$totalClosingSEK += $closingTransTotalProceedsSEK
+	$totalOpening += $openingTransAdjCostBasis
+	$totalOpeningSEK += $openingTransAdjCostBasisSEK
 
-		$k4 += [ordered]@{
-			"Purchased" = $ct.openingTransDateAcquired;
-			"Sold" =  $ct.closingTransDateSold;
-			"Symbol" = $ct.symbol ;
-			"QTY"  = $ct.quantity ;
-			"Closing Proceeds USD" = $closingTransTotalProceeds;
-			"Closing Proceeds SEK" = $closingTransTotalProceedsSEK;
-			"Purchase Price USD" = $openingTransAdjCostBasis;
-			"Purchase Price SEK" = $openingTransAdjCostBasisSEK;
-		}
+	$k4 += [ordered]@{
+		"Purchased" = $ct.openingTransDateAcquired;
+		"Sold" =  $ct.closingTransDateSold;
+		"Symbol" = $ct.symbol ;
+		"QTY"  = $ct.quantity ;
+		"Closing Proceeds USD" = $closingTransTotalProceeds;
+		"Closing Proceeds SEK" = $closingTransTotalProceedsSEK;
+		"Purchase Price USD" = $openingTransAdjCostBasis;
+		"Purchase Price SEK" = $openingTransAdjCostBasisSEK;
 	}
 }
 
 $totalClosing = [math]::Round($totalClosing)
 $totalOpening = [math]::Round($totalOpening)
 
-Write-Warning "Please note that this script does not include fees or commisions. Make sure to adjust against the fees in your account orders report."
+Write-Warning "Please note that while this script generally does account for fees and commisions (by using Total Proceeds: The dollar value of the transaction after the deduction of any commissions and fees), it does not include disbursement fees if you deposit the proceeds in your Securities account, as opposed to wiring them out of E-Trade immediately.`n`nWhere the proceeds have been deposited can be checked in At Work -> My Account -> Orders, and expanding the individual orders.`n`nKeeping track of where to add the wire fee in this case is beyond the scope of this script, but you can look at wire history for the last 12 months by going to At Work -> My Account -> Holdings -> Other Holdings and expanding the Cash section.`n`nOne way to account for it is to divide the wire fee (can be worked out by the difference of the Wire Out value and the Shares Sold-Cash Proceeds Received) between the sell orders contributing to the wire amount, and subtracting that number from their respective Closing Proceeds USD (remember to recalculate the SEK afterwards)."
 
 Write-Output 'Marknadsnoterade aktier, adktieindexobligationer, aktieoptioner m.m. / Listed shares, share index bonds, share options, etc.'
 


### PR DESCRIPTION
The SOAP API doesn't work since 2024-05-27 ([see press release](https://www.riksbank.se/en-gb/statistics/interest-rates-and-exchange-rates/retrieving-interest-rates-and-exchange-rates-via-api/outgoing-api-soap/)). The replacement REST API is much simpler, but is also rate-limited, so we must query rates for the maximum interval of relevant dates and query the individual days locally instead.

Includes some drive-by fixes.